### PR TITLE
Create Campaign has a new required attribute

### DIFF
--- a/REST APIs.postman_collection.json
+++ b/REST APIs.postman_collection.json
@@ -686,9 +686,15 @@
 													"type": "text"
 												},
 												{
+													"key": "number_pooling_required",
+													"value": "true",
+													"description": "Will 50 or more numbers be used with this single campaign? Answer true or false.",
+													"type": "text"
+												},
+												{
 													"key": "number_pooling_per_campaign",
-													"value": "no ",
-													"description": "Will 50 or more numbers be used with this single campaign? If answering yes, please provide an explanation as to why it is needed.",
+													"value": "Each rep must have their own phone number",
+													"description": "If number pooling will be used, please provide an explanation as to why it is needed.",
 													"type": "text"
 												},
 												{


### PR DESCRIPTION
references https://github.com/signalwire/cloud-product/issues/5196 and https://github.com/signalwire/prime-rails/pull/3572

TCR requires a boolean true/false on number pooling, rather than eliminate the string `number_pooling_ per_campaign` that currently exists, we chose to add `number_pooling_required` instead. `number_pooling_required` is a required field and `number_pooling_ per_campaign` is only required if `number_pooling_required` is true. 

## Do not merge yet, I will merge when the changes have been deployed 