### PR TITLE
Add New Project API Token Endpoints to REST and Compatibility API Collections

### DIFF
--- a/Compatibility API.postman_collection.json
+++ b/Compatibility API.postman_collection.json
@@ -3395,6 +3395,121 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Tokens",
+			"item": [
+				{
+					"name": "Create API Token",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\"name\": \"My Token\",\n\"permissions\": [\"calling\", \"chat\", \"fax\", \"messaging\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{Space}}/api/laml/2010-04-01/Accounts/{{Proj}}/tokens",
+							"protocol": "https",
+							"host": [
+								"{{Space}}"
+							],
+							"path": [
+								"api",
+								"laml",
+								"2010-04-01",
+								"Accounts",
+								"{{Proj}}",
+								"tokens"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Token",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\"name\": \"Update\",\n\"permissions\": [\"calling\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{Space}}/api/laml/2010-04-01/Accounts/{{Proj}}/tokens/:token_id",
+							"protocol": "https",
+							"host": [
+								"{{Space}}"
+							],
+							"path": [
+								"api",
+								"laml",
+								"2010-04-01",
+								"Accounts",
+								"{{Proj}}",
+								"tokens",
+								":token_id"
+							],
+							"variable": [
+								{
+									"key": "token_id",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Token",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\"name\": \"Updated Token\",\n\"permissions\": [\"calling\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{Space}}/api/laml/2010-04-01/Accounts/{{Proj}}/tokens/:token_id",
+							"protocol": "https",
+							"host": [
+								"{{Space}}"
+							],
+							"path": [
+								"api",
+								"laml",
+								"2010-04-01",
+								"Accounts",
+								"{{Proj}}",
+								"tokens",
+								":token_id"
+							],
+							"variable": [
+								{
+									"key": "token_id",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"auth": {

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ In this repo you'll find 2 collections that can be imported into Postman:
   - Message API
   - Fax API
   - Voice API
+  - Project API
   
 Once you’re logged into Postman, you can click **Import** in the top left corner, choose the **File** tab and select the downloaded collection(s).
 
@@ -25,4 +26,3 @@ You can get the required credentials [in your space](https://developer.signalwir
 - Space -> Your Space URL (spacename.signalwire.com, no prepended https://)
 
 If you choose to use different variable names in your environment to represent the required authentication variables, you will need to change them at the collection level as well! Hover over the collection and click the three dots, then click Edit. Go to the authorization tag and adjust the environment variables to match your new names. 
-

--- a/REST APIs.postman_collection.json
+++ b/REST APIs.postman_collection.json
@@ -3059,7 +3059,7 @@
 			]
 		},
 		{
-			"name": "Project",
+			"name": "Project API",
 			"item": [
 				{
 					"name": "Tokens",

--- a/REST APIs.postman_collection.json
+++ b/REST APIs.postman_collection.json
@@ -3057,7 +3057,119 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Project",
+			"item": [
+				{
+					"name": "Tokens",
+					"item": [
+						{
+							"name": "Create API Token",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\"name\": \"My Token\",\n\"permissions\": [\"calling\", \"chat\", \"fax\", \"messaging\"]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://{{Space}}/api/project/tokens",
+									"protocol": "https",
+									"host": [
+										"{{Space}}"
+									],
+									"path": [
+										"api",
+										"project",
+										"tokens"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Token",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\"name\": \"Updated Token\",\n\"permissions\": [\"calling\"]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://{{Space}}/api/project/tokens/:token_id",
+									"protocol": "https",
+									"host": [
+										"{{Space}}"
+									],
+									"path": [
+										"api",
+										"project",
+										"tokens",
+										":token_id"
+									],
+									"variable": [
+										{
+											"key": "token_id",
+											"value": ""
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Token",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\"name\": \"Updated Token\",\n\"permissions\": [\"calling\"]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://{{Space}}/api/project/tokens/:token_id",
+									"protocol": "https",
+									"host": [
+										"{{Space}}"
+									],
+									"path": [
+										"api",
+										"project",
+										"tokens",
+										":token_id"
+									],
+									"variable": [
+										{
+											"key": "token_id",
+											"value": ""
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
 		}
+
 	],
 	"auth": {
 		"type": "basic",


### PR DESCRIPTION
We recently introduced new project API token endpoints for our REST API and our Compatibility API. 

[Project API Token Endpoints - REST API](https://developer.signalwire.com/rest/generate-a-new-api-token)

[Project API Token Endpoints - Compatibility API](https://developer.signalwire.com/compatibility-api/rest/generate-a-new-api-token)

We should include these in our Postman collections so they are available for customers to use easily with minimal configuration required. 